### PR TITLE
job title

### DIFF
--- a/src/constants/app-icons.ts
+++ b/src/constants/app-icons.ts
@@ -18,6 +18,7 @@ export const AppIcons = {
   INVALID_FORM: 'alert-circle-outline',
   INTERNAL_USER: 'account',
   MORE_DETAILS: 'information-outline',
+  JOB_TITLE: 'badge-account-horizontal',
 };
 
 export type AppIconsType = typeof AppIcons;

--- a/src/constants/menus.ts
+++ b/src/constants/menus.ts
@@ -41,7 +41,7 @@ export const Menus: MenuItemContract[] = [
   {
     id: MenuIdes.JOB_TITLE,
     langKey: 'menu_job_title',
-    icon: AppIcons.SETTINGS,
+    icon: AppIcons.JOB_TITLE,
     path: AppFullRoutes.JOB_TITLE,
     parent: MenuIdes.ADMINISTRATION,
   },

--- a/src/modules/administration/components/job-title/job-title.component.html
+++ b/src/modules/administration/components/job-title/job-title.component.html
@@ -58,16 +58,15 @@
 
     <!-- status status -->
     <ng-container matColumnDef="status">
-      <th mat-header-cell mat-sort-header="status" *matHeaderCellDef>{{ lang.map.status }}</th>
+      <th mat-header-cell mat-sort-header="status" *matHeaderCellDef class="status-min-width">{{ lang.map.status }}</th>
       <td mat-cell *matCellDef="let element">
         <mat-slide-toggle
-          [disabled]="(loading$ | async)!"
+          [disabled]="(loading$ | async)! || !element.isEditable()"
           class="cursor-not-allowed"
-          [matTooltip]="lang.map.change_status"
+          [matTooltip]="element.isEditable() ? lang.map.change_status : ''"
           color="primary"
-          (click)="status$.next(element)"
+          (toggleChange)="status$.next(element)"
           [checked]="element.isActive()">
-          <span>{{ element.statusInfo.getNames() }}</span>
         </mat-slide-toggle>
       </td>
     </ng-container>

--- a/src/modules/administration/components/job-title/job-title.component.ts
+++ b/src/modules/administration/components/job-title/job-title.component.ts
@@ -67,9 +67,7 @@ export class JobTitleComponent extends AdminComponent<
     ),
     new SelectFilterColumn(
       'jobType',
-      this.lookupService.lookups.userType.filter(
-        (i) => i.lookupKey !== UserTypes.ALL
-      ),
+      this.lookupService.lookups.userType,
       'lookupKey',
       'getNames'
     ),

--- a/src/modules/administration/popups/job-title-popup/job-title-popup.component.ts
+++ b/src/modules/administration/popups/job-title-popup/job-title-popup.component.ts
@@ -24,10 +24,7 @@ export class JobTitlePopupComponent
 
   lookupService = inject(LookupService);
 
-  jobTypes: Lookup[] = this.lookupService.lookups.userType.filter(
-    // exclude 'All' entry from lookupMaps that backend returns, waiting for Ebrahim to fix that
-    (usertype) => usertype.lookupKey !== UserTypes.ALL
-  );
+  jobTypes: Lookup[] = this.lookupService.lookups.userType;
 
   get status(): AbstractControl {
     return this.form.get('status')!;


### PR DESCRIPTION
- Change job title menu icon.
- Undo filtering 'All' job type value since one job title could be assigned to all user types (job types).
- Set the localization of "job_type" to be (user type/نوع المستخدم).